### PR TITLE
遷移先(枠組み)の作成

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,19 @@
 <script setup lang="ts">
-import RealTimeClock from "./components/realTimeClock.vue"
-import {useHead} from "@vueuse/head"
+import { RouterLink, RouterView } from 'vue-router'
 
-useHead({
-  title:'メインページ'
-})
+
 </script>
 
 <template>
-<h2>メインページ</h2>
-<div>
-<RealTimeClock/>
-</div>
+  <header>
+    <nav>
+      <RouterLink to="/">ホーム</RouterLink><br />
+      <RouterLink to="/monthly">月次勤怠</RouterLink><br />
+      <RouterLink to="/dayly">日次勤怠</RouterLink><br />
+    </nav>
+  </header>
+<h2>e-navi-mock</h2>
+<RouterView/>
 </template>
 
 

--- a/src/components/realTimeClock.vue
+++ b/src/components/realTimeClock.vue
@@ -19,7 +19,7 @@ onMounted(() => {
 <template>
   <div>
     <p>
-      今日は&nbsp;<span style="font-weight: 900; font-size: 1.4em; color: red">{{
+      今日は&nbsp;<span style="font-weight: 500; font-size: 1.4em; color: red">{{
         currentDate
       }}</span
       >&nbsp;です
@@ -27,10 +27,9 @@ onMounted(() => {
   </div>
   <div>
     <p>
-      現在の時刻は&nbsp;<span style="font-weight: 650; font-size: 1.4em">{{ currentTime }}</span
+      現在の時刻は&nbsp;<span style="font-weight: 250; font-size: 1.4em">{{ currentTime }}</span
       >&nbsp;です
     </p>
   </div>
-  <br>
   <diV><p>今日もお仕事、がんばりましょう…</p></diV>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import './assets/main.css'
+// import './assets/main.css'
 
 import { createApp } from 'vue'
 import {createHead} from '@vueuse/head'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import NotFound from '../views/NotFound.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -9,13 +10,28 @@ const router = createRouter({
       name: 'home',
       component: HomeView
     },
+    // {
+    //   path: '/about',
+    //   name: 'about',
+    //   // route level code-splitting
+    //   // this generates a separate chunk (About.[hash].js) for this route
+    //   // which is lazy-loaded when the route is visited.
+    //   component: () => import('../views/AboutView.vue')
+    // },
     {
-      path: '/about',
-      name: 'about',
-      // route level code-splitting
-      // this generates a separate chunk (About.[hash].js) for this route
-      // which is lazy-loaded when the route is visited.
-      component: () => import('../views/AboutView.vue')
+      path: '/monthly',
+      name: 'monthlyt',
+      component: () => import('../views/MonthlyView.vue')
+    },
+    {
+      path: '/dayly',
+      name: 'dayly',
+      component: () => import('../views/DaylyView.vue')
+    },
+    {
+      path: '/:pathmatch(.*)*',
+      name: 'notFound',
+      component: NotFound
     }
   ]
 })

--- a/src/views/DaylyView.vue
+++ b/src/views/DaylyView.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useHead } from '@vueuse/head';
+useHead({
+  title:'日次勤怠'
+})
+
+
+</script>
+
+<template>
+    <h2>月次勤怠</h2>
+</template>

--- a/src/views/DaylyView.vue
+++ b/src/views/DaylyView.vue
@@ -8,5 +8,5 @@ useHead({
 </script>
 
 <template>
-    <h2>月次勤怠</h2>
+    <h2>日次勤怠</h2>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
-import TheWelcome from '../components/TheWelcome.vue'
+// import TheWelcome from '../components/TheWelcome.vue'
+import RealTimeClock from "../components/realTimeClock.vue"
+import { useHead } from "@vueuse/head";
+useHead({
+  title:'メインページ'
+})
 </script>
 
 <template>
   <main>
-    <TheWelcome />
+    <h3>ホーム</h3>
+    <div><RealTimeClock/></div>
   </main>
 </template>

--- a/src/views/MonthlyView.vue
+++ b/src/views/MonthlyView.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import { useHead } from '@vueuse/head';
+useHead({
+  title:'月次勤怠'
+})
+</script>
+
+<template>
+    <h2>月次勤怠</h2>
+</template>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,5 @@
+<template>
+    <h2>Not Found</h2>
+    <p>アクセスしたページは存在しません</p>
+    <div><button @click="$router.push({path:'/'})">ホーム</button></div>
+</template>


### PR DESCRIPTION
## 概要
- 日時を表示させるコンポーネントをApp.vueに直に載せてしまっていたので、HomeView.vueに移動
- ヘッダーに月次勤怠と日次勤怠を設定。遷移先の作成(中身はゼロ)
- エラーページ(NotFound.vue)の作成