### PR TITLE
ログインページ(骨組み)の実装

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
-import NotFound from '../views/NotFound.vue'
+import NotFound from '../views/NotFound.vue' 
+import Login from '../views/LoginView.vue'
+
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -8,32 +10,53 @@ const router = createRouter({
     {
       path: '/',
       name: 'home',
-      component: HomeView
+      component: HomeView,
+      meta:{requiresAuth:false}
+      // バックの実装が完了したらtrueに修正します
     },
-    // {
-    //   path: '/about',
-    //   name: 'about',
-    //   // route level code-splitting
-    //   // this generates a separate chunk (About.[hash].js) for this route
-    //   // which is lazy-loaded when the route is visited.
-    //   component: () => import('../views/AboutView.vue')
-    // },
     {
       path: '/monthly',
       name: 'monthlyt',
-      component: () => import('../views/MonthlyView.vue')
+      component: () => import('../views/MonthlyView.vue'),
+      meta:{requiresAuth:false}
+      // バックの実装が完了したらtrueに修正します
     },
     {
       path: '/dayly',
       name: 'dayly',
-      component: () => import('../views/DaylyView.vue')
+      component: () => import('../views/DaylyView.vue'),
+      meta:{requiresAuth:false}
+      // バックの実装が完了したらtrueに修正します
     },
     {
       path: '/:pathmatch(.*)*',
       name: 'notFound',
-      component: NotFound
+      component: NotFound,
+      
+    },
+    {
+      path: '/login',
+      name: 'login',
+      component: Login,
+      meta:{requiresAuth:false}
+      // ここはfalse
     }
   ]
 })
+
+// 上記をtrueに設定したらログインが完了してないと、('/login')にリダイレクトする作りにしています
+router.beforeEach((to,from,next)=>{
+  if(to.meta.requiresAuth){
+    const isAuthenticated = false
+    if(isAuthenticated){
+      next()
+    }else{
+      next('/login')
+    }
+  }else{
+    next()
+  }
+})
+
 
 export default router

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useHead } from '@vueuse/head';
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+
+useHead({
+  title:'ログイン'
+})
+
+const email = ref('')
+const password = ref('')
+const router = useRouter()
+
+const isAuthenticated = ref(false)
+
+const login = () =>{
+  isAuthenticated.value = !isAuthenticated.value  
+  router.push('/')
+}
+</script>
+
+<template>
+    <div>
+    <form @submit.prevent="login">
+    <h2>ログイン</h2>
+    <input type="email" v-model="email" placeholder="メールアドレス" required>
+    <br>
+    <input type="password" v-model="password" placeholder="パスワード" required>
+    <br>
+    <button type="submit">ログイン</button>
+</form>
+</div>
+</template>

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+import { useHead } from '@vueuse/head';
+useHead({
+  title:'存在しないページ'
+})
+</script>
+
 <template>
     <h2>Not Found</h2>
     <p>アクセスしたページは存在しません</p>


### PR DESCRIPTION
## 概要
- ログインページの骨組みを実装しました
- 現在は'http://localhost:5173/login'に直接いかないと表示できません
- メアドとパスワードで認証のイメージです(今はただフォームだけ何を入れても遷移します)
- データベース周りの実装を終えて、index.tsのルート設定の真偽をfalse→trueに修正することで、未ログイン時にログイン画面にリダイレクトするようにしてます。