### PR TITLE
セレクトタグの選択肢を他にもDBから取得するようにしました

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,3 +38,8 @@ model Notification {
   create_user Int
   read_user   Int[]
 }
+
+model Shift {
+  id         Int    @id @default(autoincrement())
+  name String
+}

--- a/src/components/CalenderTable.vue
+++ b/src/components/CalenderTable.vue
@@ -143,6 +143,7 @@ function generateCalendar() {
   border: 1px solid #ccc;
   max-height: 200px;
   overflow-y: auto;
+  display: none;
 }
 
 .dropdown-menu li {

--- a/src/components/SampleAttendance.vue
+++ b/src/components/SampleAttendance.vue
@@ -35,8 +35,8 @@ const tardinessData = ref([] as TardinessData[])
 const fetchTardinessClass = async () => {
   try {
     const response = await axios.get('http://localhost:4242/tardiness')
-    tardinessData.value = response.data.allTardinessClass
-    console.log('遅刻項目', response.data.allTardinessClass)
+    tardinessData.value = response.data
+    console.log('遅刻項目', response.data)
   } catch (error) {
     console.error(error)
   }
@@ -56,6 +56,9 @@ const defaultTardinessStatus = ref('')
       <option v-for="data in attendanceData" :key="data.name">{{ data.name }}</option>
     </select>
   </div>
+  <ul>
+    <li v-for="data in tardinessData" :key="data.name">{{ data.name }}</li>
+  </ul>
   <div>
     <select v-model="defaultTardinessStatus">
       <option v-for="data in tardinessData" :key="data.name">{{ data.name }}</option>

--- a/src/components/SampleAttendance.vue
+++ b/src/components/SampleAttendance.vue
@@ -2,66 +2,91 @@
 import axios from 'axios'
 import { onMounted, ref } from 'vue'
 
-interface AttedanceData {
-  name: string
-}
 
-const attendanceData = ref([] as AttedanceData[])
+// 出欠
+// interface AttedanceData {
+//   name: string
+// }
 
-const fetchAttendantClass = async () => {
-  try {
-    const response = await axios.get('http://localhost:4242/attendance')
-    attendanceData.value = response.data.allAttendantClass
-    console.log('出欠項目', response.data)
-  } catch (error) {
-    console.error(error)
-  }
-}
-onMounted(() => {
-  fetchAttendantClass()
+// const attendanceData = ref([] as AttedanceData[])
+
+// const fetchAttendantClass = async () => {
+//   try {
+//     const response = await axios.get('http://localhost:4242/attendance')
+//     attendanceData.value = response.data.allAttendantClass
+//     console.log('出欠項目', response.data)
+//   } catch (error) {
+//     console.error(error)
+//   }
+// }
+// onMounted(() => {
+//   fetchAttendantClass()
   
-})
+// })
 
-const defaultAttendantStatus = ref('')
+// const defaultAttendantStatus = ref('')
 
-//
 
-interface TardinessData {
+//遅刻理由
+// interface TardinessData {
+//   name: string
+// }
+
+// const tardinessData = ref([] as TardinessData[])
+
+// const fetchTardinessClass = async () => {
+//   try {
+//     const response = await axios.get('http://localhost:4242/tardiness')
+//     tardinessData.value = response.data.allTardinessClass
+//     console.log('遅刻項目', response.data)
+//   } catch (error) {
+//     console.error(error)
+//   }
+// }
+// onMounted(() => {
+//   fetchTardinessClass()
+// })
+
+// const defaultTardinessStatus = ref('')
+
+// 状態
+interface State {
   name: string
 }
 
-const tardinessData = ref([] as TardinessData[])
+const stateData = ref([] as State[])
 
-const fetchTardinessClass = async () => {
+const fetchState = async () => {
   try {
-    const response = await axios.get('http://localhost:4242/tardiness')
-    tardinessData.value = response.data
-    console.log('遅刻項目', response.data)
+    const response = await axios.get('http://localhost:4242/state')
+    stateData.value = response.data.allState
+    console.log('状態項目', response.data.allState)
   } catch (error) {
     console.error(error)
   }
 }
 onMounted(() => {
-  fetchTardinessClass()
+  fetchState()
 })
 
-const defaultTardinessStatus = ref('')
-
+const defaultState = ref('')
 </script>
 
 <template>
   <p>後で消す</p>
-  <div>
+  <!-- <div>
     <select v-model="defaultAttendantStatus">
       <option v-for="data in attendanceData" :key="data.name">{{ data.name }}</option>
     </select>
   </div>
-  <ul>
-    <li v-for="data in tardinessData" :key="data.name">{{ data.name }}</li>
-  </ul>
   <div>
     <select v-model="defaultTardinessStatus">
       <option v-for="data in tardinessData" :key="data.name">{{ data.name }}</option>
+    </select>
+  </div> -->
+  <div>
+    <select v-model="defaultState">
+      <option v-for="data in stateData" :key="data.name">{{ data.name }}</option>
     </select>
   </div>
 </template>

--- a/src/controllers/attendanceController.ts
+++ b/src/controllers/attendanceController.ts
@@ -1,0 +1,12 @@
+import { PrismaClient,  } from '@prisma/client'
+import { Router } from 'express'
+
+const prisma = new PrismaClient()
+const router = Router()
+
+router.get('/', async (req, res) => {
+  const allAttendantClass = await prisma.attendance.findMany()
+  res.json({ allAttendantClass })
+})
+
+export default router

--- a/src/controllers/shiftController.ts
+++ b/src/controllers/shiftController.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client'
+import { Router } from 'express'
+
+const prisma = new PrismaClient()
+const router = Router()
+
+router.get('/', async (req, res) => {
+  const allShiftData = await prisma.shift.findMany()
+  res.json({ allShiftData })
+})
+
+export default router

--- a/src/controllers/stateController.ts
+++ b/src/controllers/stateController.ts
@@ -1,0 +1,12 @@
+import { PrismaClient,  } from '@prisma/client'
+import { Router } from 'express'
+
+const prisma = new PrismaClient()
+const router = Router()
+
+router.get('/', async (req, res) => {
+  const allState = await prisma.attendance.findMany()
+  res.json({ allState })
+})
+
+export default router

--- a/src/controllers/tardinessController.ts
+++ b/src/controllers/tardinessController.ts
@@ -1,0 +1,12 @@
+import { PrismaClient,  } from '@prisma/client'
+import { Router } from 'express'
+
+const prisma = new PrismaClient()
+const router = Router()
+
+router.get('/', async (req, res) => {
+  const allState = await prisma.attendance.findMany()
+  res.json({ allState })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,10 @@ import express from 'express'
 // import userController from './controllers/userController'
 import dailyAttendanceController from './controllers/dailyAttendanceController'
 import monthlyAttendanceController from './controllers/mothlyAttendanceController'
+import attendanceController from './controllers/attendanceController'
+import tardinessController from './controllers/tardinessController'
+import stateController from './controllers/stateController'
+import shiftController from './controllers/shiftController'
 
 const app: express.Express = express()
 const port = 3000
@@ -14,6 +18,10 @@ app.get('/', (req, res) => {
 
 app.use('/day', dailyAttendanceController)
 app.use('/month', monthlyAttendanceController)
+app.use('/attendance',attendanceController)
+app.use('/tardiness',tardinessController)
+app.use('/state',stateController) 
+app.use('/shift',shiftController)
 
 export const server = app.listen(port, () => {
   console.log(`this app listening on port ${port}`)


### PR DESCRIPTION
## 概要
- 出欠に続いてシフトと遅刻理由も取得しています
- そのため、schema.prismaとseed.tsを少しいじっています
- 状態(state)はなぜかほかのテーブルから情報を引っ張ってきてしまうので、鋭意、対応していきます
- その他、日時勤怠のポスト画面で初期表示の設定をいくつか行っています

※気づかぬうちにgithubからサインアウトしており、プルリクができない状態が続いていて
それに気づくまでかなり時間を要しました…すみません